### PR TITLE
Fix typo in error message

### DIFF
--- a/R/G.matrix.R
+++ b/R/G.matrix.R
@@ -12,7 +12,7 @@ G.matrix <- function(M, method=c("VanRaden", "UAR", "UARadj", "GK"), format=c("w
   p <- colMeans(M)/2
   
   if(any(p == 0 | p == 1))
-    stop("Monomorphic markers are no allowed")
+    stop("Monomorphic markers are not allowed")
 
   WWG <- function(M, p){
     w <- scale(x = M, center = T, scale = F)


### PR DESCRIPTION
Fixing type on error message "stop("Monomorphic markers are not allowed")" no -> not line 15